### PR TITLE
feat: untilIdで取得できるように

### DIFF
--- a/src/@types/index.d.ts
+++ b/src/@types/index.d.ts
@@ -1,4 +1,4 @@
-import { entities } from "misskey-js"
+import { entities, Endpoints } from "misskey-js"
 
 export type Server = {
   origin: string
@@ -18,4 +18,8 @@ export type RankElement = {
   userId: string,
   rank: number,
   noteId: string
+}
+
+export type TimelineOptions = Endpoints['notes/hybrid-timeline']['req'] & {
+  excludeNsfw?: boolean
 }


### PR DESCRIPTION
## 概要

misskey2023.10.1からのTL変更でsinceDate(sinceId)が使用不可能になるためsinceIdではなくuntilIdで取得するようにオプション`GET_UNTIL_BASE`を追加しました。

misskey.ioでのテスト取得をしています。

## 補足

±1分の間に収まっていないノートが混在したことでsinceとuntilで結果に齟齬が生じていたためfilterで切り落としています。