### PR TITLE
1.1.0-beta.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yamag",
-  "version": "1.1.0-beta",
+  "version": "1.1.0-beta.1",
   "description": "Yet Another Misskey Accuracy Game app",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yamag",
-  "version": "1.1.0-beta.1",
+  "version": "1.1.0-beta.2",
   "description": "Yet Another Misskey Accuracy Game app",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yamag",
-  "version": "1.0.0",
+  "version": "1.1.0-beta",
   "description": "Yet Another Misskey Accuracy Game app",
   "main": "index.js",
   "scripts": {

--- a/src/@types/index.d.ts
+++ b/src/@types/index.d.ts
@@ -1,4 +1,4 @@
-import { entities } from "misskey-js"
+import { entities, Endpoints } from "misskey-js"
 
 export type Server = {
   origin: string
@@ -20,4 +20,8 @@ export type RankElement = {
   userId: string,
   rank: number,
   noteId: string
+}
+
+export type TimelineOptions = Endpoints['notes/hybrid-timeline']['req'] & {
+  excludeNsfw?: boolean
 }

--- a/src/@types/index.d.ts
+++ b/src/@types/index.d.ts
@@ -5,7 +5,9 @@ export type Server = {
   credential: string
 }
 
-export type Note = entities.Note
+export type Note = entities.note & {
+  updatedAt?: Date | null
+}
 
 export type Record = {
   note: Note,

--- a/src/index.ts
+++ b/src/index.ts
@@ -82,9 +82,9 @@ const getLastNote = (notes:Array<Note>) => notes.slice(-1)[0];
 
 const getNotes = async ():Promise<Array<Note>> => {
   // EXPERIMENTAL_EXPERIMENTAL_USE_UNTILが有効時のみuntilを利用してTL取得
-  if (Config.Experimental.useUntil) return getNotesUsingSince()
+  if (Config.Experimental.useUntil) return getNotesUsingUntil()
 
-  return getNotesUsingUntil()
+  return getNotesUsingSince()
 }
 
 const getNotesUsingSince = async ():Promise<Array<Note>> => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -145,6 +145,7 @@ const getNotes = async ():Promise<Array<Note>> => {
   let filteredNotes = recordedNotes.filter(note => {
     return !['334', Config.userName].includes(note.user.username) &&
             ['public', 'relational' , 'home'].includes(note.visibility) &&
+           ![null, undefined].includes(note?.updatedAt) &&
             note.user.host === null
   })
   console.log(`対象のノート: ${filteredNotes.length}件`)

--- a/src/index.ts
+++ b/src/index.ts
@@ -77,9 +77,17 @@ const raiseOmittedTimeline = (notes:Note[]) => {
   }
 }
 
+const getFirstNote = (notes:Array<Note>) => notes[0];
 const getLastNote = (notes:Array<Note>) => notes.slice(-1)[0];
 
 const getNotes = async ():Promise<Array<Note>> => {
+  // EXPERIMENTAL_EXPERIMENTAL_USE_UNTILが有効時のみuntilを利用してTL取得
+  if (Config.Experimental.useUntil) return getNotesUsingSince()
+
+  return getNotesUsingUntil()
+}
+
+const getNotesUsingSince = async ():Promise<Array<Note>> => {
   const since = Config.recordTime.getTime() - (60 * 1000)
   const until = Config.recordTime.getTime() + (60 * 1000)
   const options = {
@@ -135,6 +143,67 @@ const getNotes = async ():Promise<Array<Note>> => {
   return notes
 }
 
+// Experimental: UntilDate, UntilIdを用いてTLを取得する 
+const getNotesUsingUntil = async ():Promise<Array<Note>> => {
+  const since = Config.recordTime.getTime() - (60 * 1000)
+  const until = Config.recordTime.getTime() + (60 * 1000)
+  const options = {
+    excludeNsfw: false,
+    limit: 100,
+    untilDate: until
+  }
+  console.log('loading notes...')
+  let notes = await retry(
+    async ()=> {
+      console.log(`Getting latest notes (1 minute previous)`)
+      const req = await YAMAG.Misskey.request('notes/hybrid-timeline', options)
+
+      raiseOmittedTimeline(req)
+
+      return req
+    },
+    {
+      retries: NOTE_GET_RETRY_COUNT,
+      minTimeout: 5000,
+      onRetry: (err, num)=> {
+        console.log(`get note retrying...${num}`)
+        console.debug(err)
+      }
+    }
+  )
+  notes = notes.reverse()
+
+  if (notes.length === 0) return []
+
+  while (new Date(getFirstNote(notes).createdAt).getTime() > since) {
+    console.log(`since: ${since}`)
+    console.log(`now last: ${new Date(getFirstNote(notes).createdAt).getTime()}`)
+    const oldNotes = await retry(async ()=> {
+        console.log(`Getting notes: {untilId: ${getFirstNote(notes).id}}`)
+        const req = await YAMAG.Misskey.request('notes/hybrid-timeline', {
+          untilId: getFirstNote(notes).id,
+          ...options
+        })
+
+        raiseOmittedTimeline(req)
+
+        return req
+      }, {
+        retries: NOTE_GET_RETRY_COUNT,
+        minTimeout: 5000,
+        onRetry: (err, num)=> {
+          console.log(`get note retrying...${num}`)
+          console.debug(err)
+        }
+      }
+    )
+    notes = oldNotes.reverse().concat(notes)
+    console.log(notes.length)
+    await new Promise((resolve) => setTimeout(resolve, 500))
+  }
+  return notes
+}
+
 (async ()=>{
   console.log("getNotes start")
   notes = await getNotes()
@@ -145,7 +214,7 @@ const getNotes = async ():Promise<Array<Note>> => {
   let filteredNotes = recordedNotes.filter(note => {
     return !['334', Config.userName].includes(note.user.username) &&
             ['public', 'relational' , 'home'].includes(note.visibility) &&
-           ![null, undefined].includes(note?.updatedAt) &&
+            [null, undefined].includes(note?.updatedAt) &&
             note.user.host === null
   })
   console.log(`対象のノート: ${filteredNotes.length}件`)
@@ -164,7 +233,7 @@ const getNotes = async ():Promise<Array<Note>> => {
       console.debug(err)
     }
   }).then(async n => {
-    console.log('投稿完了')
+    console.log('投稿の処理まで完了')
   }).catch(err => {
     console.log("ノート投稿の失敗が既定の回数を超えました")
     console.log(err)

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 import YAMAG from '@/utils/misskey'
-import { Note, Record } from '@/@types'
+import { Note, Record, TimelineOptions } from '@/@types'
 import { RankElement, usernameWithHost, isRecordInRange } from '@/utils'
 import Config from '@/utils/config'
 import { Constants } from '@/utils/constants'
@@ -90,7 +90,7 @@ const getNotes = async ():Promise<Array<Note>> => {
 const getNotesUsingSince = async ():Promise<Array<Note>> => {
   const since = Config.recordTime.getTime() - (60 * 1000)
   const until = Config.recordTime.getTime() + (60 * 1000)
-  const options = {
+  const options: TimelineOptions = {
     excludeNsfw: false,
     limit: 100,
     sinceDate: since

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -9,7 +9,14 @@ const parseIntWithDefalult = (v:any, def:number):number => Number.isFinite(parse
 const today = new Date()
 const recordTimeHour = parseIntWithDefalult(process.env.RECORD_HOUR, 3)
 const recordTimeMinute = parseIntWithDefalult(process.env.RECORD_MINUTE, 34)
-export const recordTime = new Date(today.getFullYear(), today.getMonth(), today.getDate(), recordTimeHour, recordTimeMinute, 0, 0)
+export const recordTime = (() => {
+  // 23:59など集計が日付を挟む場合には1日前を参照する
+  let target = new Date(today.getFullYear(), today.getMonth(), today.getDate(), recordTimeHour, recordTimeMinute, 0, 0)
+  const todayMidnight = new Date(today.getFullYear(), today.getMonth(), today.getDate(), 0, 0, 0, 0)
+  // 一日前 = 86_400_000秒前
+  if (target.getTime() - todayMidnight.getTime()) target = new Date(target.getTime() - 86_400_000)
+  return target
+})()
 
 export const postTitle = process.env?.POST_TITLE || `Today's 334 Top 10`
 export const remindPostText = process.env?.REMINED_POST_TEXT || `334観測中`
@@ -29,6 +36,10 @@ export const server:Server = {
   credential: process.env.SERVER_TOKEN || ''
 }
 
+export const Experimental = {
+  useUntil: process.env?.EXPERIMENTAL_USE_UNTIL === 'TRUE'
+}
+
 export const isDbEnabled = ():boolean => !!DATABASE_URL
 
-export default {recordTime, postTitle, remindPostText, matcher, userName, server, isDbEnabled, mention}
+export default {recordTime, postTitle, remindPostText, matcher, userName, server, isDbEnabled, mention, Experimental}


### PR DESCRIPTION
編集されたノートを集計外に resolve: #87
untilIdを用いて取得可能にする fix: #89
前の日の結果も含めた前回の結果を集計可能に